### PR TITLE
Fix infer arguments

### DIFF
--- a/notebooks/2. Bayesian Networks.ipynb
+++ b/notebooks/2. Bayesian Networks.ipynb
@@ -477,7 +477,7 @@
    "source": [
     "from pgmpy.inference import VariableElimination\n",
     "infer = VariableElimination(model)\n",
-    "print(infer.query('G') ['G'])"
+    "print(infer.query(['G']) ['G'])"
    ]
   },
   {
@@ -516,7 +516,7 @@
     }
    ],
    "source": [
-    "print(infer.query('G', evidence={'D': 0, 'I': 1}) ['G'])"
+    "print(infer.query(['G'], evidence={'D': 0, 'I': 1}) ['G'])"
    ]
   },
   {


### PR DESCRIPTION
The current notebook calls `infer.query('G')`, this only works because the name of the node is a single character. This argument should be a list of nodes instead. See also issue #12.

:beers: