### PR TITLE
Adapt to import structure in pgmpy.factors

### DIFF
--- a/notebooks/6. Parameterizing with Continuous Variables.ipynb
+++ b/notebooks/6. Parameterizing with Continuous Variables.ipynb
@@ -503,7 +503,6 @@
     }
    ],
    "source": [
-    "# from pgmpy.factors.continuous import CanonicalFactor\n",
     "from pgmpy.factors.continuous import CanonicalDistribution\n",
     "\n",
     "phi1 = CanonicalDistribution(['x1', 'x2', 'x3'],\n",
@@ -740,7 +739,7 @@
    ],
    "source": [
     "from pgmpy.models import LinearGaussianBayesianNetwork\n",
-    "from pgmpy.factors.continuous import LinearGaussianCPD\n",
+    "\n",
     "model = LinearGaussianBayesianNetwork([('x1', 'x2'), ('x2', 'x3')])\n",
     "cpd1 = LinearGaussianCPD('x1', [1], 4)\n",
     "cpd2 = LinearGaussianCPD('x2', [-5, 0.5], 4, ['x1'])\n",

--- a/notebooks/6. Parameterizing with Continuous Variables.ipynb
+++ b/notebooks/6. Parameterizing with Continuous Variables.ipynb
@@ -2,10 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from IPython.display import Image"
@@ -53,10 +51,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -66,16 +62,14 @@
     "def drichlet_pdf(x, y):\n",
     "     return (np.power(x, 1)*np.power(y, 2))/beta(x, y)\n",
     "\n",
-    "from pgmpy.factors import ContinuousFactor\n",
+    "from pgmpy.factors.continuous import ContinuousFactor\n",
     "drichlet_factor = ContinuousFactor(['x', 'y'], drichlet_pdf)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -83,7 +77,7 @@
        "(['x', 'y'], 226800.0)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -101,10 +95,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def custom_pdf(x, y, z):\n",
@@ -115,10 +107,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -126,7 +116,7 @@
        "(['x', 'y', 'z'], 24.0)"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,10 +127,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -148,7 +136,7 @@
        "(['x', 'z'], 24.0)"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -160,10 +148,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -171,7 +157,7 @@
        "(['x1', 'x2'], 0.058549831524319168)"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -186,10 +172,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -197,7 +181,7 @@
        "(['x1'], 0.24197072451914328)"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -209,10 +193,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -220,7 +202,7 @@
        "(0.063493635934240983, 0.3989422804014327)"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -274,38 +256,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.0014805631279234139"
+       "['x1', 'x2', 'x3']"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from pgmpy.factors import JointGaussianDistribution as JGD\n",
+    "from pgmpy.factors.distributions import GaussianDistribution as JGD\n",
     "dis = JGD(['x1', 'x2', 'x3'], np.array([[1], [-3], [4]]),\n",
     "          np.array([[4, 2, -2], [2, 5, -5], [-2, -5, 8]]))\n",
-    "dis.variables\n",
-    "dis.mean\n",
-    "dis.covariance\n",
-    "dis.pdf([0,0,0])"
+    "dis.variables"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -315,7 +290,7 @@
        "       [ 4.]])"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -326,10 +301,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -339,7 +312,7 @@
        "       [-2., -5.,  8.]])"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -350,10 +323,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 14,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -361,7 +332,7 @@
        "0.0014805631279234139"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -379,10 +350,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -390,7 +359,7 @@
        "['x1', 'x2', 'x3', 'x4']"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -400,15 +369,13 @@
     "           np.array([[4, 2, -2], [2, 5, -5], [-2, -5, 8]]))\n",
     "dis2 = JGD(['x3', 'x4'], [1, 2], [[2, 3], [5, 6]])\n",
     "dis3 = dis1 * dis2\n",
-    "dis3.scope()"
+    "dis3.variables"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 16,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -419,7 +386,7 @@
        "       [ 3.5]])"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -430,10 +397,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -444,7 +409,7 @@
        "       [-1. , -2.5,  4. ,  4.5]])"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -523,10 +488,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -534,29 +497,29 @@
        "['x1', 'x2', 'x3']"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from pgmpy.factors import CanonicalFactor\n",
-    "phi1 = CanonicalFactor(['x1', 'x2', 'x3'],\n",
+    "# from pgmpy.factors.continuous import CanonicalFactor\n",
+    "from pgmpy.factors.continuous import CanonicalDistribution\n",
+    "\n",
+    "phi1 = CanonicalDistribution(['x1', 'x2', 'x3'],\n",
     "                       np.array([[1, -1, 0], [-1, 4, -2], [0, -2, 4]]),\n",
     "                       np.array([[1], [4], [-1]]), -2)\n",
-    "phi2 = CanonicalFactor(['x1', 'x2'], np.array([[3, -2], [-2, 4]]),\n",
+    "phi2 = CanonicalDistribution(['x1', 'x2'], np.array([[3, -2], [-2, 4]]),\n",
     "                       np.array([[5], [-1]]), 1)\n",
     "\n",
     "phi3 = phi1 * phi2\n",
-    "phi3.scope()"
+    "phi3.variables"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -566,7 +529,7 @@
        "       [-1.]])"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -577,10 +540,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -590,7 +551,7 @@
        "       [ 0., -2.,  4.]])"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -601,10 +562,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 21,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -612,7 +571,7 @@
        "-1"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -630,10 +589,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 22,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -641,13 +598,13 @@
        "['x1', 'x2']"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "phi = CanonicalFactor(['x1', 'x2'], np.array([[3, -2], [-2, 4]]),\n",
+    "phi = CanonicalDistribution(['x1', 'x2'], np.array([[3, -2], [-2, 4]]),\n",
     "                      np.array([[5], [-1]]), 1)\n",
     "jgd = phi.to_joint_gaussian()\n",
     "jgd.variables"
@@ -655,10 +612,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 23,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -667,7 +622,7 @@
        "       [ 0.25 ,  0.375]])"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -678,10 +633,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 24,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -690,7 +643,7 @@
        "       [ 0.875]])"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -740,23 +693,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 25,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "P(Y| X1, X2, X3) = N(-2*X1_mu + 3*X2_mu + 7*X3_mu; 0.2)\n"
+      "P(Y | X1, X2, X3) = N(-2*X1 + 3*X2 + 7*X3 + 0.2; 9.6)\n"
      ]
     }
    ],
    "source": [
     "# For P(Y| X1, X2, X3) = N(-2x1 + 3x2 + 7x3 + 0.2; 9.6)\n",
-    "from pgmpy.factors import LinearGaussianCPD\n",
-    "cpd = LinearGaussianCPD('Y', 0.2, 9.6, ['X1', 'X2', 'X3'], [-2, 3, 7])\n",
+    "from pgmpy.factors.continuous import LinearGaussianCPD\n",
+    "cpd = LinearGaussianCPD('Y',  [0.2, -2, 3, 7], 9.6, ['X1', 'X2', 'X3'])\n",
     "print(cpd)"
    ]
   },
@@ -773,10 +724,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 26,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -784,17 +733,24 @@
        "['x1', 'x2', 'x3']"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "from pgmpy.models import LinearGaussianBayesianNetwork\n",
+    "from pgmpy.factors.continuous import LinearGaussianCPD\n",
     "model = LinearGaussianBayesianNetwork([('x1', 'x2'), ('x2', 'x3')])\n",
-    "cpd1 = LinearGaussianCPD('x1', 1, 4)\n",
-    "cpd2 = LinearGaussianCPD('x2', -5, 4, ['x1'], [0.5])\n",
-    "cpd3 = LinearGaussianCPD('x3', 4, 3, ['x2'], [-1])\n",
+    "cpd1 = LinearGaussianCPD('x1', [1], 4)\n",
+    "cpd2 = LinearGaussianCPD('x2', [-5, 0.5], 4, ['x1'])\n",
+    "cpd3 = LinearGaussianCPD('x3', [4, -1], 3, ['x2'])\n",
+    "# This is a hack due to a bug in pgmpy (LinearGaussianCPD\n",
+    "# doesn't have `variables` attribute but `add_cpds` function\n",
+    "# wants to check that...)\n",
+    "cpd1.variables = [*cpd1.evidence, cpd1.variable]\n",
+    "cpd2.variables = [*cpd2.evidence, cpd2.variable]\n",
+    "cpd3.variables = [*cpd3.evidence, cpd3.variable]\n",
     "model.add_cpds(cpd1, cpd2, cpd3)\n",
     "jgd = model.to_joint_gaussian()\n",
     "jgd.variables"
@@ -802,10 +758,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 27,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -815,7 +769,7 @@
        "       [ 8.5]])"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -826,10 +780,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 28,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -839,7 +791,7 @@
        "       [-2., -5.,  8.]])"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -851,9 +803,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pgmpy",
    "language": "python",
-   "name": "python3"
+   "name": "pgmpy"
   },
   "language_info": {
    "codemirror_mode": {
@@ -865,9 +817,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Seems that we cannot import everything we need directly from `pgmpy.factors`, symbols are separated into sub modules (but I feel it a little messy). To be concrete,

* `from pgmpy.factors import JointGaussianDistribution as JGD` -> `from pgmpy.factors.distributions import GaussianDistribution as JGD`
* `from pgmpy.factors import CanonicalFactor` -> `from pgmpy.factors.continuous import CanonicalDistribution`
* `from pgmpy.factors import LinearGaussianCPD` -> `from pgmpy.factors.continuous import LinearGaussianCPD`

(There is also a bug in the implementation of `LinearGaussianBayesianNetwork.add_cpds` so the notebook contains a little hack to deal with that which should be removed after the bug fixed.)