### PR TITLE
Fixed TypeError Bug in inference examples

### DIFF
--- a/notebooks/2. Bayesian Networks.ipynb
+++ b/notebooks/2. Bayesian Networks.ipynb
@@ -680,35 +680,28 @@
     }
    ],
    "source": [
-    "infer.map_query(['G'], evidence={'D': 'Easy', 'I': 'Intelligent'})"
+    "source": [
+    "infer.map_query(['G'], evidence={'D': 0, 'I': 1})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Finding Elimination Order: : : 0it [00:00, ?it/s]\n",
-      "0it [00:00, ?it/s]\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "{'G': 'A'}"
+       "{'G': 0}"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "infer.map_query(['G'], evidence={'D': 'Easy', 'I': 'Intelligent', 'L': 'Good', 'S': 'Good'})"
+    "infer.map_query(['G'], evidence={'D': 0, 'I': 1, 'L': 1, 'S': 1})"
    ]
   },
   {
@@ -736,7 +729,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
The inference examples were passing evidence of type {string : string} when {string : index} was expected. As a result, this tutorial was producing a the following error:
TypeError: values: must contain tuples or array-like elements of the form (hashable object, type int)
