### PR TITLE
Use X_train instead of data to calculate the joint probabilitites

### DIFF
--- a/notebooks/1. Introduction to Probabilistic Graphical Models.ipynb
+++ b/notebooks/1. Introduction to Probabilistic Graphical Models.ipynb
@@ -457,7 +457,7 @@
    ],
    "source": [
     "# Computing the joint probability distribution over the training data\n",
-    "joint_prob = data.groupby(['length', 'width', 'type']).size() / 120\n",
+    "joint_prob = X_train.groupby(['length', 'width', 'type']).size() / 120\n",
     "joint_prob"
    ]
   },


### PR DESCRIPTION
Example joint probability used all of the data instead of using only the training data. The error was obvious if one summed the joint probabilities before which was 1.25 (instead of 1).